### PR TITLE
fix: ansible deprecation warnings in debian.yml

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -5,12 +5,12 @@
     - name: Setting amd64 architecture
       ansible.builtin.set_fact:
         shell_arch: amd64
-      when: ansible_architecture == "x86_64"
+      when: ansible_facts.architecture == "x86_64"
 
     - name: Setting arm64 architecture
       ansible.builtin.set_fact:
         shell_arch: arm64
-      when: ansible_architecture == "aarch64"
+      when: ansible_facts.architecture == "aarch64"
 
     - name: Install prereq packages
       ansible.builtin.apt:


### PR DESCRIPTION
```
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
``` 